### PR TITLE
Update package and repository name to goslide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For a full API reference, see the official [Slide API Documentation](https://doc
   - Download and install Go, version 1.23+, from the [official Go website](https://go.dev/doc/install).
   - Obtain your Slide API Token and review the **[Authentication](https://docs.slide.tech/api/#description/authentication)** section.
   - Open your editor of choice, create a new directory and initialize your Go project.
-  - Open a terminal and navigate to the directory of your project, then run: `go get github.com/equalsgibson/slide@latest`
+  - Open a terminal and navigate to the directory of your project, then run: `go get github.com/equalsgibson/goslide@latest`
 
 ### Quickstart
 After following the above steps, you could create a simple `main.go` file and include the following to list all your current Slide Devices:
@@ -48,14 +48,14 @@ After following the above steps, you could create a simple `main.go` file and in
 
 ```golang
 ...
-	// Create the slide service by calling slide.NewService
-	slideService := slide.NewService(slideAuthToken)
+	// Create the slide service by calling goslide.NewService
+	slide := goslide.NewService(slideAuthToken)
 
 	fmt.Println("Querying Slide API for devices...")
 
 	ctx := context.Background()
-	slideDevices := []slide.Device{}
-	if err := slideService.Devices().List(ctx, func(response slide.ListResponse[slide.Device]) error {
+	slideDevices := []goslide.Device{}
+	if err := slide.Devices().List(ctx, func(response goslide.ListResponse[goslide.Device]) error {
 		slideDevices = append(slideDevices, response.Data...)
 
 		return nil

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ For a full API reference, see the official [Slide API Documentation](https://doc
 
 ### Quickstart
 After following the above steps, you could create a simple `main.go` file and include the following to list all your current Slide Devices:
-  
-![Quickstart Demo](/ops/docs/assets/quickstart.gif)
+
 
 ```golang
 ...
@@ -66,6 +65,8 @@ After following the above steps, you could create a simple `main.go` file and in
 	}
 ...
 ```
+
+![Quickstart Demo](/ops/docs/assets/quickstart.gif)
 
 ### More Examples
 

--- a/account.go
+++ b/account.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/account_test.go
+++ b/account_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestAccount_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestAccount_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Account{}
+	actual := []goslide.Account{}
 
 	ctx := context.Background()
 	if err := testService.Accounts().List(ctx,
-		func(response slide.ListResponse[slide.Account]) error {
+		func(response goslide.ListResponse[goslide.Account]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestAccount_List(t *testing.T) {
 func TestAccount_Update(t *testing.T) {
 	accountID := "act_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -119,13 +119,13 @@ func TestAccount_Update(t *testing.T) {
 		),
 	)
 
-	expected := slide.Account{
+	expected := goslide.Account{
 		AccountID:   "act_0123456789ab",
 		AccountName: "Slide Inc.",
 		AlertEmails: []string{
 			"john.doe@gmail.com",
 		},
-		BillingAddress: slide.BillingAddress{
+		BillingAddress: goslide.BillingAddress{
 			City:       "New York",
 			Country:    "US",
 			Line1:      "123 Main St",
@@ -153,8 +153,8 @@ func TestAccount_Update(t *testing.T) {
 func TestAccount_Get(t *testing.T) {
 	accountID := "act_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -181,7 +181,7 @@ func TestAccount_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Account{
+	expected := goslide.Account{
 		AccountID:   "act_0123456789ab",
 		AccountName: "Slide Inc.",
 		AlertEmails: []string{
@@ -189,7 +189,7 @@ func TestAccount_Get(t *testing.T) {
 			"jane.smith@example.com",
 			"user123@domain.net",
 		},
-		BillingAddress: slide.BillingAddress{
+		BillingAddress: goslide.BillingAddress{
 			City:       "New York",
 			Country:    "US",
 			Line1:      "123 Main St",

--- a/agent.go
+++ b/agent.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestAgent_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestAgent_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Agent{}
+	actual := []goslide.Agent{}
 
 	ctx := context.Background()
 	if err := testService.Agents().List(ctx,
-		func(response slide.ListResponse[slide.Agent]) error {
+		func(response goslide.ListResponse[goslide.Agent]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestAgent_List(t *testing.T) {
 func TestAgent_Update(t *testing.T) {
 	agentID := "a_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -119,7 +119,7 @@ func TestAgent_Update(t *testing.T) {
 		),
 	)
 
-	expected := slide.Agent{
+	expected := goslide.Agent{
 		AgentID:             agentID,
 		AgentVersion:        "1.2.3",
 		BootedAt:            generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -135,7 +135,7 @@ func TestAgent_Update(t *testing.T) {
 		OSVersion:           "10.0.19042",
 		Platform:            "Microsoft Windows 10 Home",
 		PublicIPAddress:     "74.83.124.111",
-		Addresses: []slide.Address{
+		Addresses: []goslide.Address{
 			{
 				IPs: []string{
 					"192.168.1.104",
@@ -160,8 +160,8 @@ func TestAgent_Update(t *testing.T) {
 func TestAgent_Get(t *testing.T) {
 	agentID := "a_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -182,7 +182,7 @@ func TestAgent_Get(t *testing.T) {
 		),
 	)
 
-	expected := slide.Agent{
+	expected := goslide.Agent{
 		AgentID:             agentID,
 		AgentVersion:        "1.2.3",
 		BootedAt:            generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -198,7 +198,7 @@ func TestAgent_Get(t *testing.T) {
 		OSVersion:           "10.0.19042",
 		Platform:            "Microsoft Windows 10 Home",
 		PublicIPAddress:     "74.83.124.111",
-		Addresses: []slide.Address{
+		Addresses: []goslide.Address{
 			{
 				IPs: []string{
 					"192.168.1.104",
@@ -221,8 +221,8 @@ func TestAgent_Get(t *testing.T) {
 }
 
 func TestAgent_AutoPair(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -266,14 +266,14 @@ func TestAgent_AutoPair(t *testing.T) {
 		),
 	)
 
-	expected := slide.AgentAutoPairResponse{
+	expected := goslide.AgentAutoPairResponse{
 		AgentID:     "a_0123456789ab",
 		DisplayName: "My Agent",
 		PairCode:    "ABC123",
 	}
 
 	ctx := context.Background()
-	actual, err := testService.Agents().AutoPair(ctx, slide.AgentAutoPairPayload{
+	actual, err := testService.Agents().AutoPair(ctx, goslide.AgentAutoPairPayload{
 		DeviceID:    "d_0123456789ab",
 		DisplayName: "My Agent",
 	})
@@ -288,8 +288,8 @@ func TestAgent_AutoPair(t *testing.T) {
 }
 
 func TestAgent_Pair(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -333,7 +333,7 @@ func TestAgent_Pair(t *testing.T) {
 		),
 	)
 
-	expected := slide.Agent{
+	expected := goslide.Agent{
 		AgentID:             "a_0123456789ab",
 		AgentVersion:        "1.2.3",
 		BootedAt:            generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -349,7 +349,7 @@ func TestAgent_Pair(t *testing.T) {
 		OSVersion:           "10.0.19042",
 		Platform:            "Microsoft Windows 10 Home",
 		PublicIPAddress:     "74.83.124.111",
-		Addresses: []slide.Address{
+		Addresses: []goslide.Address{
 			{
 				IPs: []string{
 					"192.168.1.104",
@@ -361,7 +361,7 @@ func TestAgent_Pair(t *testing.T) {
 
 	ctx := context.Background()
 
-	actual, err := testService.Agents().Pair(ctx, slide.AgentPairPayload{
+	actual, err := testService.Agents().Pair(ctx, goslide.AgentPairPayload{
 		DeviceID: "d_0123456789ab",
 		PairCode: "ABC123",
 	})

--- a/alert.go
+++ b/alert.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestAlert_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestAlert_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Alert{}
+	actual := []goslide.Alert{}
 
 	ctx := context.Background()
 	if err := testService.Alerts().List(ctx,
-		func(response slide.ListResponse[slide.Alert]) error {
+		func(response goslide.ListResponse[goslide.Alert]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestAlert_List(t *testing.T) {
 func TestAlert_Update(t *testing.T) {
 	alertID := "al_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -121,7 +121,7 @@ func TestAlert_Update(t *testing.T) {
 
 	resolvedTime := generateRFC3389FromString(t, "2024-08-23T01:25:08Z")
 
-	expected := slide.Alert{
+	expected := goslide.Alert{
 		AgentID:     "a_0123456789ab",
 		AlertFields: "string",
 		AlertID:     alertID,
@@ -148,8 +148,8 @@ func TestAlert_Update(t *testing.T) {
 func TestAlert_Get(t *testing.T) {
 	alertID := "al_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -178,7 +178,7 @@ func TestAlert_Get(t *testing.T) {
 
 	resolvedTime := generateRFC3389FromString(t, "2024-08-23T01:25:08Z")
 
-	expected := slide.Alert{
+	expected := goslide.Alert{
 		AgentID:     "a_0123456789ab",
 		AlertFields: "string",
 		AlertID:     alertID,
@@ -209,8 +209,8 @@ func TestAlert_Get(t *testing.T) {
 func TestAlert_GetUnresolved(t *testing.T) {
 	alertID := "al_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -237,7 +237,7 @@ func TestAlert_GetUnresolved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Alert{
+	expected := goslide.Alert{
 		AgentID:     "a_0123456789ab",
 		AlertFields: "string",
 		AlertID:     alertID,

--- a/backup.go
+++ b/backup.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/backup_test.go
+++ b/backup_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestBackup_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestBackup_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Backup{}
+	actual := []goslide.Backup{}
 
 	ctx := context.Background()
 	if err := testService.Backups().List(ctx,
-		func(response slide.ListResponse[slide.Backup]) error {
+		func(response goslide.ListResponse[goslide.Backup]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -72,8 +72,8 @@ func TestBackup_List(t *testing.T) {
 }
 
 func TestBackup_StartBackup(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -125,8 +125,8 @@ func TestBackup_StartBackup(t *testing.T) {
 
 func TestBackup_Get(t *testing.T) {
 	agentID := "al_0123456789ab"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -153,7 +153,7 @@ func TestBackup_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Backup{
+	expected := goslide.Backup{
 		AgentID:      "a_0123456789ab",
 		BackupID:     "b_0123456789ab",
 		EndedAt:      generateRFC3389FromString(t, "2024-08-23T01:40:08Z"),
@@ -161,7 +161,7 @@ func TestBackup_Get(t *testing.T) {
 		ErrorMessage: "string",
 		SnapshotID:   "s_0123456789ab",
 		StartedAt:    generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
-		Status:       slide.BackupStatus_SUCCEEDED,
+		Status:       goslide.BackupStatus_SUCCEEDED,
 	}
 
 	if diff := cmp.Diff(expected, actual); diff != "" {

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestClient_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestClient_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Client{}
+	actual := []goslide.Client{}
 
 	ctx := context.Background()
 	if err := testService.Clients().List(ctx,
-		func(response slide.ListResponse[slide.Client]) error {
+		func(response goslide.ListResponse[goslide.Client]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -72,8 +72,8 @@ func TestClient_List(t *testing.T) {
 }
 
 func TestClient_Create(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -117,13 +117,13 @@ func TestClient_Create(t *testing.T) {
 		),
 	)
 
-	expected := slide.Client{
+	expected := goslide.Client{
 		Name:     "My Client",
 		Comments: "",
 		ClientID: "c_123456789abc",
 	}
 
-	payload := slide.ClientPayload{
+	payload := goslide.ClientPayload{
 		Name: "My Client",
 	}
 
@@ -143,8 +143,8 @@ func TestClient_Create(t *testing.T) {
 func TestClient_Get(t *testing.T) {
 	clientID := "c_123456789abc"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -171,7 +171,7 @@ func TestClient_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Client{
+	expected := goslide.Client{
 		ClientID: clientID,
 		Comments: "This is a test client",
 		Name:     "Slide Office",
@@ -185,8 +185,8 @@ func TestClient_Get(t *testing.T) {
 func TestClient_Delete(t *testing.T) {
 	clientID := "c_123456789abc"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -214,8 +214,8 @@ func TestClient_Delete(t *testing.T) {
 
 func TestClient_Update(t *testing.T) {
 	clientID := "c_123456789abc"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -259,13 +259,13 @@ func TestClient_Update(t *testing.T) {
 		),
 	)
 
-	expected := slide.Client{
+	expected := goslide.Client{
 		Name:     "My Client",
 		Comments: "",
 		ClientID: clientID,
 	}
 
-	payload := slide.ClientPayload{
+	payload := goslide.ClientPayload{
 		Name: "My Client",
 	}
 

--- a/device.go
+++ b/device.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/device_test.go
+++ b/device_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestDevice_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestDevice_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Device{}
+	actual := []goslide.Device{}
 
 	ctx := context.Background()
 	if err := testService.Devices().List(ctx,
-		func(response slide.ListResponse[slide.Device]) error {
+		func(response goslide.ListResponse[goslide.Device]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestDevice_List(t *testing.T) {
 func TestDevice_Get(t *testing.T) {
 	deviceID := "d_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -102,8 +102,8 @@ func TestDevice_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Device{
-		Addresses: []slide.Address{
+	expected := goslide.Device{
+		Addresses: []goslide.Address{
 			{
 				IPs: []string{
 					"192.168.1.104",
@@ -138,8 +138,8 @@ func TestDevice_Get(t *testing.T) {
 func TestDevice_Update(t *testing.T) {
 	deviceID := "d_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -184,7 +184,7 @@ func TestDevice_Update(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.Devices().Update(ctx, deviceID, slide.DevicePayload{
+	actual, err := testService.Devices().Update(ctx, deviceID, goslide.DevicePayload{
 		DisplayName: "My Device",
 		Hostname:    "my-device",
 	})
@@ -192,8 +192,8 @@ func TestDevice_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Device{
-		Addresses: []slide.Address{
+	expected := goslide.Device{
+		Addresses: []goslide.Address{
 			{
 				IPs: []string{
 					"192.168.1.104",

--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"fmt"

--- a/examples/create_file_restore/main.go
+++ b/examples/create_file_restore/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/equalsgibson/slide"
+	"github.com/equalsgibson/goslide"
 )
 
 /**
@@ -48,7 +48,7 @@ func main() {
 
 	// * NOTE:
 	// If you do not want to make actual network requests, include a custom roundtripper, similar to the example below
-	// slideService := slide.NewService(strings.TrimSuffix(slideAuthToken, "\n"), slide.WithCustomRoundtripper(
+	// slideService := goslide.NewService(strings.TrimSuffix(slideAuthToken, "\n"), goslide.WithCustomRoundtripper(
 	// 	roundtripper.MockNetworkQueue(
 	// 		[]roundtripper.MockRoundTripFunc{
 	// 			roundtripper.Serve(&roundtripper.MockResponseFile{
@@ -75,14 +75,14 @@ func main() {
 	// 	),
 	// ))
 
-	slideService := slide.NewService(strings.TrimSuffix(slideAuthToken, "\n"))
+	slideService := goslide.NewService(strings.TrimSuffix(slideAuthToken, "\n"))
 
 	ctx := context.Background()
 
 	fmt.Println("Querying Slide API for agents...")
 
-	agents := []slide.Agent{}
-	if err := slideService.Agents().List(ctx, func(response slide.ListResponse[slide.Agent]) error {
+	agents := []goslide.Agent{}
+	if err := slideService.Agents().List(ctx, func(response goslide.ListResponse[goslide.Agent]) error {
 		agents = append(agents, response.Data...)
 
 		return nil
@@ -117,15 +117,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	snapshots := []slide.Snapshot{}
+	snapshots := []goslide.Snapshot{}
 	if err := slideService.Snapshots().ListWithQueryParameters(
 		ctx,
-		func(response slide.ListResponse[slide.Snapshot]) error {
+		func(response goslide.ListResponse[goslide.Snapshot]) error {
 			snapshots = append(snapshots, response.Data...)
 
 			return nil
 		},
-		slide.WithAgentID(agents[agentIDInt].AgentID),
+		goslide.WithAgentID(agents[agentIDInt].AgentID),
 	); err != nil {
 		fmt.Printf("Encountered error while querying snapshots for agent (%s) from Slide API: %s\n", agents[agentIDInt].AgentID, err.Error())
 
@@ -159,7 +159,7 @@ func main() {
 
 	fmt.Printf("Creating a File Restore for the following Agent and Snapshot:\n\n\tAgent:\t%s\n\tSnapshot:\t%s\n\tDevice:\t%s\n", agents[agentIDInt].AgentID, snapshots[snapshotIDInt].SnapshotID, agents[agentIDInt].DeviceID)
 
-	fileRestore, err := slideService.FileRestores().Create(ctx, slide.FileRestorePayload{
+	fileRestore, err := slideService.FileRestores().Create(ctx, goslide.FileRestorePayload{
 		DeviceID:   agents[agentIDInt].DeviceID,
 		SnapshotID: snapshots[snapshotIDInt].SnapshotID,
 	})

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/equalsgibson/slide"
+	"github.com/equalsgibson/goslide"
 )
 
 /**
@@ -31,7 +31,7 @@ func main() {
 
 	// * NOTE:
 	// If you do not want to make actual network requests, include a custom roundtripper, similar to the example below
-	// slideService := slide.NewService(strings.TrimSuffix(slideAuthToken, "\n"), slide.WithCustomRoundtripper(
+	// slideService := goslide.NewService(strings.TrimSuffix(slideAuthToken, "\n"), goslide.WithCustomRoundtripper(
 	// 	roundtripper.MockNetworkQueue(
 	// 		[]roundtripper.MockRoundTripFunc{
 	// 			roundtripper.Serve(&roundtripper.MockResponseFile{
@@ -46,15 +46,15 @@ func main() {
 	// 	),
 	// ))
 
-	// Create the slide service by calling slide.NewService
-	slideService := slide.NewService(slideAuthToken)
+	// Create the slide service by calling goslide.NewService
+	slideService := goslide.NewService(slideAuthToken)
 
 	fmt.Println("Querying Slide API for devices...")
 
 	ctx := context.Background()
 
-	slideDevices := []slide.Device{}
-	if err := slideService.Devices().List(ctx, func(response slide.ListResponse[slide.Device]) error {
+	slideDevices := []goslide.Device{}
+	if err := slideService.Devices().List(ctx, func(response goslide.ListResponse[goslide.Device]) error {
 		slideDevices = append(slideDevices, response.Data...)
 
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/equalsgibson/slide
+module github.com/equalsgibson/goslide
 
 go 1.23.3
 

--- a/health.go
+++ b/health.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"context"

--- a/health_test.go
+++ b/health_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"context"
@@ -8,13 +8,13 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 )
 
 func TestHealth_IsAuthenticated_InvalidToken(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -41,7 +41,7 @@ func TestHealth_IsAuthenticated_InvalidToken(t *testing.T) {
 	authenticated, err := testService.CheckAuthenticationToken(ctx)
 
 	// Confirm that the error is a slide pkg error and not a net/http or other error
-	var slideError *slide.SlideError
+	var slideError *goslide.SlideError
 	if errors.As(err, &slideError) {
 		// Validate the StatusCode is being set on the error correctly.
 		if slideError.HTTPStatusCode != http.StatusUnauthorized {
@@ -49,8 +49,8 @@ func TestHealth_IsAuthenticated_InvalidToken(t *testing.T) {
 		}
 
 		// Validate the error code enum for unauthorized is in the slice of returned error codes.
-		if !slices.Contains(slideError.Codes, slide.APIErrorCode_ERR_UNAUTHORIZED) {
-			t.Fatalf("the Slide API Error did not contain the correct error code - expecting %s, actual codes: %+v", slide.APIErrorCode_ERR_UNAUTHORIZED, slideError.Codes)
+		if !slices.Contains(slideError.Codes, goslide.APIErrorCode_ERR_UNAUTHORIZED) {
+			t.Fatalf("the Slide API Error did not contain the correct error code - expecting %s, actual codes: %+v", goslide.APIErrorCode_ERR_UNAUTHORIZED, slideError.Codes)
 		}
 	} else {
 		t.Fatal("expected to receive a Slide API error")
@@ -63,8 +63,8 @@ func TestHealth_IsAuthenticated_InvalidToken(t *testing.T) {
 }
 
 func TestHealth_IsAuthenticated_MissingToken(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -91,7 +91,7 @@ func TestHealth_IsAuthenticated_MissingToken(t *testing.T) {
 	authenticated, err := testService.CheckAuthenticationToken(ctx)
 
 	// Confirm that the error is a slide pkg error and not a net/http or other error
-	var slideError *slide.SlideError
+	var slideError *goslide.SlideError
 	if errors.As(err, &slideError) {
 		// Validate the StatusCode is being set on the error correctly.
 		if slideError.HTTPStatusCode != http.StatusUnauthorized {
@@ -99,8 +99,8 @@ func TestHealth_IsAuthenticated_MissingToken(t *testing.T) {
 		}
 
 		// Validate the error code enum for missing auth token is in the slice of returned error codes.
-		if !slices.Contains(slideError.Codes, slide.APIErrorCode_ERR_MISSING_AUTHENTICATION) {
-			t.Fatalf("the Slide API Error did not contain the correct error code - expecting %s, actual codes: %+v", slide.APIErrorCode_ERR_MISSING_AUTHENTICATION, slideError.Codes)
+		if !slices.Contains(slideError.Codes, goslide.APIErrorCode_ERR_MISSING_AUTHENTICATION) {
+			t.Fatalf("the Slide API Error did not contain the correct error code - expecting %s, actual codes: %+v", goslide.APIErrorCode_ERR_MISSING_AUTHENTICATION, slideError.Codes)
 		}
 	} else {
 		t.Fatal("expected to receive a Slide API error")
@@ -113,8 +113,8 @@ func TestHealth_IsAuthenticated_MissingToken(t *testing.T) {
 }
 
 func TestHealth_IsAuthenticated_OK(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{

--- a/network.go
+++ b/network.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/network_test.go
+++ b/network_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestNetwork_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestNetwork_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Network{}
+	actual := []goslide.Network{}
 
 	ctx := context.Background()
 	if err := testService.Networks().List(ctx,
-		func(response slide.ListResponse[slide.Network]) error {
+		func(response goslide.ListResponse[goslide.Network]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestNetwork_List(t *testing.T) {
 func TestNetwork_Get(t *testing.T) {
 	networkID := "net_012345"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -96,7 +96,7 @@ func TestNetwork_Get(t *testing.T) {
 		),
 	)
 
-	expected := slide.Network{
+	expected := goslide.Network{
 		BridgeDeviceID: "d_0123456789ab",
 		ClientID:       "string",
 		Comments:       "This is a test network",
@@ -111,7 +111,7 @@ func TestNetwork_Get(t *testing.T) {
 		Nameservers:    "1.1.1.1,1.0.0.1",
 		NetworkID:      "net_012345",
 		RouterPrefix:   "10.0.0.1/24",
-		Type:           slide.NetworkTypeDisaster_STANDARD,
+		Type:           goslide.NetworkTypeDisaster_STANDARD,
 	}
 
 	ctx := context.Background()
@@ -129,8 +129,8 @@ func TestNetwork_Get(t *testing.T) {
 func TestNetwork_Delete(t *testing.T) {
 	networkID := "net_012345"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -157,8 +157,8 @@ func TestNetwork_Delete(t *testing.T) {
 }
 
 func TestNetwork_Create(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -202,7 +202,7 @@ func TestNetwork_Create(t *testing.T) {
 		),
 	)
 
-	expected := slide.Network{
+	expected := goslide.Network{
 		BridgeDeviceID: "d_0123456789ab",
 		ClientID:       "string",
 		Comments:       "This is a test network",
@@ -217,14 +217,14 @@ func TestNetwork_Create(t *testing.T) {
 		Nameservers:    "1.1.1.1,1.0.0.1",
 		NetworkID:      "net_012345",
 		RouterPrefix:   "10.0.0.1/24",
-		Type:           slide.NetworkTypeDisaster_BRIDGE_LAN,
+		Type:           goslide.NetworkTypeDisaster_BRIDGE_LAN,
 	}
 
 	ctx := context.Background()
 
-	actual, err := testService.Networks().Create(ctx, slide.NetworkCreatePayload{
+	actual, err := testService.Networks().Create(ctx, goslide.NetworkCreatePayload{
 		Name: "Bridge to LAN Network",
-		Type: slide.NetworkTypeDisaster_BRIDGE_LAN,
+		Type: goslide.NetworkTypeDisaster_BRIDGE_LAN,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pagination.go
+++ b/pagination.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"net/url"

--- a/request_client.go
+++ b/request_client.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"encoding/json"

--- a/restore_file.go
+++ b/restore_file.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/restore_file_test.go
+++ b/restore_file_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestRestore_File_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestRestore_File_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.FileRestore{}
+	actual := []goslide.FileRestore{}
 
 	ctx := context.Background()
 	if err := testService.FileRestores().List(ctx,
-		func(response slide.ListResponse[slide.FileRestore]) error {
+		func(response goslide.ListResponse[goslide.FileRestore]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestRestore_File_List(t *testing.T) {
 func TestRestore_File_Get(t *testing.T) {
 	fileRestoreID := "fr_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -102,7 +102,7 @@ func TestRestore_File_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.FileRestore{
+	expected := goslide.FileRestore{
 		AgentID:       "a_0123456789ab",
 		CreatedAt:     generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		DeviceID:      "d_0123456789ab",
@@ -119,8 +119,8 @@ func TestRestore_File_Get(t *testing.T) {
 func TestRestore_File_Delete(t *testing.T) {
 	fileRestoreID := "fr_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -147,8 +147,8 @@ func TestRestore_File_Delete(t *testing.T) {
 }
 
 func TestRestore_File_Create(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -193,7 +193,7 @@ func TestRestore_File_Create(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.FileRestores().Create(ctx, slide.FileRestorePayload{
+	actual, err := testService.FileRestores().Create(ctx, goslide.FileRestorePayload{
 		DeviceID:   "d_0123456789ab",
 		SnapshotID: "s_0123456789ab",
 	})
@@ -201,7 +201,7 @@ func TestRestore_File_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.FileRestore{
+	expected := goslide.FileRestore{
 		AgentID:       "a_0123456789ab",
 		CreatedAt:     generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		DeviceID:      "d_0123456789ab",
@@ -217,8 +217,8 @@ func TestRestore_File_Create(t *testing.T) {
 
 func TestRestore_File_Browse(t *testing.T) {
 	fileRestoreID := "fr_0123456789ab"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -253,13 +253,13 @@ func TestRestore_File_Browse(t *testing.T) {
 		),
 	)
 
-	actual := []slide.FileRestoreData{}
+	actual := []goslide.FileRestoreData{}
 
 	ctx := context.Background()
 	if err := testService.FileRestores().Browse(
 		ctx,
 		fileRestoreID,
-		func(response slide.ListResponse[slide.FileRestoreData]) error {
+		func(response goslide.ListResponse[goslide.FileRestoreData]) error {
 			actual = append(actual, response.Data...)
 
 			return nil

--- a/restore_image.go
+++ b/restore_image.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/restore_image_test.go
+++ b/restore_image_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestRestore_Image_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestRestore_Image_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.ImageExportRestore{}
+	actual := []goslide.ImageExportRestore{}
 
 	ctx := context.Background()
 	if err := testService.ImageExportRestores().List(ctx,
-		func(response slide.ListResponse[slide.ImageExportRestore]) error {
+		func(response goslide.ListResponse[goslide.ImageExportRestore]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -74,8 +74,8 @@ func TestRestore_Image_List(t *testing.T) {
 func TestRestore_Image_Get(t *testing.T) {
 	imageExportRestoreID := "ie_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -102,12 +102,12 @@ func TestRestore_Image_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.ImageExportRestore{
+	expected := goslide.ImageExportRestore{
 		AgentID:       "a_0123456789ab",
 		CreatedAt:     generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		DeviceID:      "d_0123456789ab",
 		ImageExportID: imageExportRestoreID,
-		ImageType:     slide.ImageExportType_VHDX,
+		ImageType:     goslide.ImageExportType_VHDX,
 		SnapshotID:    "s_0123456789ab",
 	}
 
@@ -119,8 +119,8 @@ func TestRestore_Image_Get(t *testing.T) {
 func TestRestore_Image_Delete(t *testing.T) {
 	imageExportRestoreID := "ie_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -147,8 +147,8 @@ func TestRestore_Image_Delete(t *testing.T) {
 }
 
 func TestRestore_Image_Create(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -193,21 +193,21 @@ func TestRestore_Image_Create(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.ImageExportRestores().Create(ctx, slide.ImageExportRestorePayload{
+	actual, err := testService.ImageExportRestores().Create(ctx, goslide.ImageExportRestorePayload{
 		DeviceID:   "d_0123456789ab",
-		ImageType:  slide.ImageExportType_VHDX,
+		ImageType:  goslide.ImageExportType_VHDX,
 		SnapshotID: "s_0123456789ab",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := slide.ImageExportRestore{
+	expected := goslide.ImageExportRestore{
 		AgentID:       "a_0123456789ab",
 		CreatedAt:     generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		DeviceID:      "d_0123456789ab",
 		ImageExportID: "ie_0123456789ab",
-		ImageType:     slide.ImageExportType_VHDX,
+		ImageType:     goslide.ImageExportType_VHDX,
 		SnapshotID:    "s_0123456789ab",
 	}
 
@@ -218,8 +218,8 @@ func TestRestore_Image_Create(t *testing.T) {
 
 func TestRestore_Image_Browse(t *testing.T) {
 	imageExportRestoreID := "ie_0123456789ab"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -254,13 +254,13 @@ func TestRestore_Image_Browse(t *testing.T) {
 		),
 	)
 
-	actual := []slide.ImageExportRestoreData{}
+	actual := []goslide.ImageExportRestoreData{}
 
 	ctx := context.Background()
 	if err := testService.ImageExportRestores().Browse(
 		ctx,
 		imageExportRestoreID,
-		func(response slide.ListResponse[slide.ImageExportRestoreData]) error {
+		func(response goslide.ListResponse[goslide.ImageExportRestoreData]) error {
 			actual = append(actual, response.Data...)
 
 			return nil

--- a/restore_virtual_machine.go
+++ b/restore_virtual_machine.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"bytes"

--- a/restore_virtual_machine_test.go
+++ b/restore_virtual_machine_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"bytes"
@@ -11,14 +11,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestRestore_Virtual_Machine_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -53,11 +53,11 @@ func TestRestore_Virtual_Machine_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.VirtualMachineRestore{}
+	actual := []goslide.VirtualMachineRestore{}
 
 	ctx := context.Background()
 	if err := testService.VirtualMachineRestores().List(ctx,
-		func(response slide.ListResponse[slide.VirtualMachineRestore]) error {
+		func(response goslide.ListResponse[goslide.VirtualMachineRestore]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -73,8 +73,8 @@ func TestRestore_Virtual_Machine_List(t *testing.T) {
 
 func TestRestore_Virtual_Machine_Get(t *testing.T) {
 	virtualMachineRestoreID := "virt_0123456789ab"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -101,7 +101,7 @@ func TestRestore_Virtual_Machine_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.VirtualMachineRestore{
+	expected := goslide.VirtualMachineRestore{
 		AgentID:      "a_0123456789ab",
 		CPUCount:     2,
 		CreatedAt:    generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -114,11 +114,11 @@ func TestRestore_Virtual_Machine_Get(t *testing.T) {
 		SnapshotID:   "s_0123456789ab",
 		State:        "running",
 		VirtID:       "virt_0123456789ab",
-		VNC: []slide.VirtualMachineVNC{
+		VNC: []goslide.VirtualMachineVNC{
 			{
 				Host:         "192.168.1.53",
 				Port:         12345,
-				Type:         slide.VirtualMachineVNCType_LOCAL,
+				Type:         goslide.VirtualMachineVNCType_LOCAL,
 				WebsocketURI: "wss://example.com",
 			},
 		},
@@ -133,8 +133,8 @@ func TestRestore_Virtual_Machine_Get(t *testing.T) {
 func TestRestore_Virtual_Machine_Delete(t *testing.T) {
 	virtualMachineRestoreID := "virt_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -161,8 +161,8 @@ func TestRestore_Virtual_Machine_Delete(t *testing.T) {
 }
 
 func TestRestore_Virtual_Machine_Create(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -207,7 +207,7 @@ func TestRestore_Virtual_Machine_Create(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.VirtualMachineRestores().Create(ctx, slide.VirtualMachineRestoreCreatePayload{
+	actual, err := testService.VirtualMachineRestores().Create(ctx, goslide.VirtualMachineRestoreCreatePayload{
 		DeviceID:   "d_0123456789ab",
 		SnapshotID: "s_0123456789ab",
 	})
@@ -215,7 +215,7 @@ func TestRestore_Virtual_Machine_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.VirtualMachineRestore{
+	expected := goslide.VirtualMachineRestore{
 		AgentID:      "a_0123456789ab",
 		CPUCount:     2,
 		CreatedAt:    generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -228,11 +228,11 @@ func TestRestore_Virtual_Machine_Create(t *testing.T) {
 		SnapshotID:   "s_0123456789ab",
 		State:        "running",
 		VirtID:       "virt_0123456789ab",
-		VNC: []slide.VirtualMachineVNC{
+		VNC: []goslide.VirtualMachineVNC{
 			{
 				Host:         "192.168.1.53",
 				Port:         12345,
-				Type:         slide.VirtualMachineVNCType_LOCAL,
+				Type:         goslide.VirtualMachineVNCType_LOCAL,
 				WebsocketURI: "wss://example.com",
 			},
 		},
@@ -245,8 +245,8 @@ func TestRestore_Virtual_Machine_Create(t *testing.T) {
 }
 
 func TestRestore_Virtual_Machine_Create_With_Options(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -291,23 +291,23 @@ func TestRestore_Virtual_Machine_Create_With_Options(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.VirtualMachineRestores().Create(ctx, slide.VirtualMachineRestoreCreatePayload{
+	actual, err := testService.VirtualMachineRestores().Create(ctx, goslide.VirtualMachineRestoreCreatePayload{
 		DeviceID:   "d_0123456789ab",
 		SnapshotID: "s_0123456789ab",
-		BootMods: []slide.BootMod{
-			slide.BootMod_PASSWORDLESS_ADMIN_USER,
+		BootMods: []goslide.BootMod{
+			goslide.BootMod_PASSWORDLESS_ADMIN_USER,
 		},
 		CPUCount:     2,
-		DiskBus:      slide.DiskBus_SATA,
+		DiskBus:      goslide.DiskBus_SATA,
 		MemoryInMB:   4096,
-		NetworkModel: slide.VirtualMachineNetworkModel_E1000,
-		NetworkType:  slide.VirtualMachineNetworkType_BRIDGE,
+		NetworkModel: goslide.VirtualMachineNetworkModel_E1000,
+		NetworkType:  goslide.VirtualMachineNetworkType_BRIDGE,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := slide.VirtualMachineRestore{
+	expected := goslide.VirtualMachineRestore{
 		AgentID:      "a_0123456789ab",
 		CPUCount:     2,
 		CreatedAt:    generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -320,11 +320,11 @@ func TestRestore_Virtual_Machine_Create_With_Options(t *testing.T) {
 		SnapshotID:   "s_0123456789ab",
 		State:        "running",
 		VirtID:       "virt_0123456789ab",
-		VNC: []slide.VirtualMachineVNC{
+		VNC: []goslide.VirtualMachineVNC{
 			{
 				Host:         "192.168.1.53",
 				Port:         12345,
-				Type:         slide.VirtualMachineVNCType_LOCAL,
+				Type:         goslide.VirtualMachineVNCType_LOCAL,
 				WebsocketURI: "wss://example.com",
 			},
 		},
@@ -338,8 +338,8 @@ func TestRestore_Virtual_Machine_Create_With_Options(t *testing.T) {
 
 func TestRestore_Virtual_Machine_Update(t *testing.T) {
 	virtID := "virt_0123456789ab"
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -384,8 +384,8 @@ func TestRestore_Virtual_Machine_Update(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	actual, err := testService.VirtualMachineRestores().Update(ctx, virtID, slide.VirtualMachineRestoreUpdatePayload{
-		State:      slide.VirtualMachineState_RUNNING,
+	actual, err := testService.VirtualMachineRestores().Update(ctx, virtID, goslide.VirtualMachineRestoreUpdatePayload{
+		State:      goslide.VirtualMachineState_RUNNING,
 		CPUCount:   2,
 		MemoryInMB: 4096,
 		ExpiresAt:  generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -394,7 +394,7 @@ func TestRestore_Virtual_Machine_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.VirtualMachineRestore{
+	expected := goslide.VirtualMachineRestore{
 		AgentID:      "a_0123456789ab",
 		CPUCount:     2,
 		CreatedAt:    generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
@@ -407,11 +407,11 @@ func TestRestore_Virtual_Machine_Update(t *testing.T) {
 		SnapshotID:   "s_0123456789ab",
 		State:        "running",
 		VirtID:       "virt_0123456789ab",
-		VNC: []slide.VirtualMachineVNC{
+		VNC: []goslide.VirtualMachineVNC{
 			{
 				Host:         "192.168.1.53",
 				Port:         12345,
-				Type:         slide.VirtualMachineVNCType_LOCAL,
+				Type:         goslide.VirtualMachineVNCType_LOCAL,
 				WebsocketURI: "wss://example.com",
 			},
 		},

--- a/service.go
+++ b/service.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"context"

--- a/service_test.go
+++ b/service_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"testing"

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"context"

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"context"
@@ -6,14 +6,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestSnapshot_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -48,11 +48,11 @@ func TestSnapshot_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.Snapshot{}
+	actual := []goslide.Snapshot{}
 
 	ctx := context.Background()
 	if err := testService.Snapshots().List(ctx,
-		func(response slide.ListResponse[slide.Snapshot]) error {
+		func(response goslide.ListResponse[goslide.Snapshot]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -69,8 +69,8 @@ func TestSnapshot_List(t *testing.T) {
 func TestSnapshot_Get(t *testing.T) {
 	snapshotID := "s_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -97,20 +97,20 @@ func TestSnapshot_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.Snapshot{
+	expected := goslide.Snapshot{
 		AgentID:         "a_0123456789ab",
 		BackupEndedAt:   generateRFC3389FromString(t, "2024-08-23T01:40:08Z"),
 		BackupStartedAt: generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		SnapshotID:      "s_0123456789ab",
-		Locations: []slide.SnapshotLocation{
+		Locations: []goslide.SnapshotLocation{
 			{
 				DeviceID: "d_0123456789ab",
-				Type:     slide.SnapshotLocationType_LOCAL,
+				Type:     goslide.SnapshotLocationType_LOCAL,
 			},
 		},
 		VerifyBootScreenshotURL: "https://example.com",
-		VerifyBootStatus:        slide.SnapshotBootStatus_SUCCESS,
-		VerifyFSStatus:          slide.SnapshotFSStatus_SUCCESS,
+		VerifyBootStatus:        goslide.SnapshotBootStatus_SUCCESS,
+		VerifyFSStatus:          goslide.SnapshotFSStatus_SUCCESS,
 	}
 
 	if diff := cmp.Diff(expected, actual); diff != "" {
@@ -121,8 +121,8 @@ func TestSnapshot_Get(t *testing.T) {
 func TestSnapshot_Get_Deleted(t *testing.T) {
 	snapshotID := "s_0123456789ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -151,29 +151,29 @@ func TestSnapshot_Get_Deleted(t *testing.T) {
 
 	deletedAt := generateRFC3389FromString(t, "2024-08-23T01:25:08Z")
 
-	expected := slide.Snapshot{
+	expected := goslide.Snapshot{
 		AgentID:         "a_0123456789ab",
 		BackupEndedAt:   generateRFC3389FromString(t, "2024-08-23T01:40:08Z"),
 		BackupStartedAt: generateRFC3389FromString(t, "2024-08-23T01:25:08Z"),
 		SnapshotID:      "s_0123456789ab",
 		Deleted:         &deletedAt,
-		Deletions: []slide.SnapshotDeletion{
+		Deletions: []goslide.SnapshotDeletion{
 			{
 				Deleted:          deletedAt,
 				DeletedBy:        "John Smith",
 				FirstAndLastName: "John Smith",
-				Type:             slide.SnapshotLocationType_LOCAL,
+				Type:             goslide.SnapshotLocationType_LOCAL,
 			},
 		},
-		Locations: []slide.SnapshotLocation{
+		Locations: []goslide.SnapshotLocation{
 			{
 				DeviceID: "d_0123456789ab",
-				Type:     slide.SnapshotLocationType_LOCAL,
+				Type:     goslide.SnapshotLocationType_LOCAL,
 			},
 		},
 		VerifyBootScreenshotURL: "https://example.com",
-		VerifyBootStatus:        slide.SnapshotBootStatus_SUCCESS,
-		VerifyFSStatus:          slide.SnapshotFSStatus_SUCCESS,
+		VerifyBootStatus:        goslide.SnapshotBootStatus_SUCCESS,
+		VerifyFSStatus:          goslide.SnapshotFSStatus_SUCCESS,
 	}
 
 	if diff := cmp.Diff(expected, actual); diff != "" {

--- a/user.go
+++ b/user.go
@@ -1,4 +1,4 @@
-package slide
+package goslide
 
 import (
 	"context"

--- a/user_test.go
+++ b/user_test.go
@@ -1,4 +1,4 @@
-package slide_test
+package goslide_test
 
 import (
 	"context"
@@ -6,14 +6,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/equalsgibson/slide"
-	"github.com/equalsgibson/slide/internal/roundtripper"
+	"github.com/equalsgibson/goslide"
+	"github.com/equalsgibson/goslide/internal/roundtripper"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestUser_List(t *testing.T) {
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -48,11 +48,11 @@ func TestUser_List(t *testing.T) {
 		),
 	)
 
-	actual := []slide.User{}
+	actual := []goslide.User{}
 
 	ctx := context.Background()
 	if err := testService.Users().List(ctx,
-		func(response slide.ListResponse[slide.User]) error {
+		func(response goslide.ListResponse[goslide.User]) error {
 			actual = append(actual, response.Data...)
 
 			return nil
@@ -69,8 +69,8 @@ func TestUser_List(t *testing.T) {
 func TestUser_Get(t *testing.T) {
 	userID := "u_1111111111ab"
 
-	testService := slide.NewService("fakeToken",
-		slide.WithCustomRoundtripper(
+	testService := goslide.NewService("fakeToken",
+		goslide.WithCustomRoundtripper(
 			roundtripper.NetworkQueue(
 				t,
 				[]roundtripper.TestRoundTripFunc{
@@ -97,12 +97,12 @@ func TestUser_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := slide.User{
+	expected := goslide.User{
 		DisplayName: "John Doe",
 		Email:       "john.doe@gmail.com",
 		FirstName:   "John",
 		LastName:    "Doe",
-		RoleID:      slide.UserRole_AccountOwner,
+		RoleID:      goslide.UserRole_AccountOwner,
 		UserID:      userID,
 	}
 


### PR DESCRIPTION
Update package and repository name to goslide, to make it clearer that this is an unofficial Slide API library.