### PR TITLE
Update Go version and add new Task; vulncheck

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,8 +16,19 @@ tasks:
     - go tool cover -func=./ops/docs/coverage.out | awk '/^total/{print "{\"total\":\""$3"\"}"}' > ./ops/docs/coverage.json
     - go tool cover -html ./ops/docs/coverage.out -o ./ops/docs/coverage.html
 
+  vulncheck:
+    desc: "Run the govulncheck tool to identify potential vulnerabilities in the current go version"
+    precondition: 
+      sh: command -v govulncheck
+      msg: "'govulncheck' is not installed. Please install this by running 'go install golang.org/x/vuln/cmd/govulncheck@latest'"
+    cmds:
+    - govulncheck ./...
+
   lint:
     desc: "Lint the package to ensure compliance with golangci-lint"
+    precondition: 
+      sh: command -v golangci-lint
+      msg: "'golangci-lint' is not installed. Please install this and re-run the task"
     cmds:
     - golangci-lint run ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/equalsgibson/goslide
 
-go 1.23.3
+go 1.23.8
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Update Go version to 1.23.8+, to resolve the following vulnerabilities in the stdlib: 
---
=== Symbol Results ===

Vulnerability 1: GO-2025-3563

Vulnerability 2: GO-2025-3447

Vulnerability 3: GO-2025-3420

Vulnerability 4: GO-2025-3373
